### PR TITLE
Refactored CommandError and other boilerplate changes

### DIFF
--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandError.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandError.java
@@ -3,15 +3,12 @@ package io.simplesource.api;
 import io.simplesource.data.Error;
 import lombok.Value;
 
-import java.util.function.BiFunction;
-
 /**
  * A CommandError explains failures. They can be constructed from the reason type,
  * with either a {@link String} or a {@link Throwable} for more context.
  */
 @Value
 public class CommandError {
-
     /**
      * Construct a {@link CommandError} from a {@link Throwable}.
      *
@@ -50,18 +47,6 @@ public class CommandError {
      */
     public String getMessage() {
         return error.getMessage();
-    }
-
-    /**
-     * Access the reason value and either the string or the throwable context and return whatever you like.
-     *
-     * @param <A> the result type
-     * @param str the function that receives the reason and string, returning a value of the specified type
-     * @param ex the function that receives the reason and throwable, returning a value of the specified type
-     * @return the result
-     */
-    public <A> A fold(BiFunction<Reason, String, A> str, BiFunction<Reason, Throwable, A> ex){
-        return error.fold(str, ex);
     }
 
     private final Error<Reason> error;

--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandError.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandError.java
@@ -40,16 +40,16 @@ public class CommandError {
      * @return the reason
      */
     public Reason getReason() {
-        return reason.getReason();
+        return error.getReason();
     }
 
     /**
-     * The reason message accessor
+     * The error message accessor
      *
-     * @return the reason message
+     * @return the error message
      */
     public String getMessage() {
-        return reason.getMessage();
+        return error.getMessage();
     }
 
     /**
@@ -61,20 +61,13 @@ public class CommandError {
      * @return the result
      */
     public <A> A fold(BiFunction<Reason, String, A> str, BiFunction<Reason, Throwable, A> ex){
-        return reason.fold(str, ex);
+        return error.fold(str, ex);
     }
 
-    private final Error<Reason> reason;
+    private final Error<Reason> error;
 
-    private CommandError(final Error<Reason> reason) {
-        this.reason = reason;
-    }
-
-    @Override
-    public String toString() {
-        return "CommandError(" + fold(
-                (error, message) -> "Error: " + error + " Message: " + message,
-                (error, throwable) -> "Error: " + error + " Throwable: " + throwable) + ')';
+    private CommandError(final Error<Reason> error) {
+        this.error = error;
     }
 
     public enum Reason {

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
@@ -3,7 +3,6 @@ package io.simplesource.kafka.internal.client;
 import io.simplesource.api.CommandAPI;
 import io.simplesource.api.CommandError;
 import io.simplesource.data.FutureResult;
-import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
 import io.simplesource.kafka.api.CommandSerdes;
@@ -12,14 +11,10 @@ import io.simplesource.kafka.dsl.KafkaConfig;
 import io.simplesource.kafka.model.CommandRequest;
 import io.simplesource.kafka.model.CommandResponse;
 import io.simplesource.kafka.spec.CommandSpec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -28,7 +23,6 @@ import java.util.function.Function;
 import static io.simplesource.kafka.api.AggregateResources.TopicEntity.*;
 
 public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
-    private static final Logger logger = LoggerFactory.getLogger(KafkaCommandAPI.class);
 
     private KafkaRequestAPI<K, CommandRequest<K, C>, CommandResponse> requestApi;
 
@@ -71,7 +65,7 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
 
         FutureResult<Exception, RequestPublisher.PublishResult> publishResult = requestApi.publishRequest(request.key(), request.commandId(), commandRequest);
 
-        return publishResult.leftMap(KafkaCommandAPI::getCommandError)
+        return publishResult.errorMap(KafkaCommandAPI::getCommandError)
                 .map(r -> request.commandId());
     }
 

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaRequestAPI.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaRequestAPI.java
@@ -149,7 +149,7 @@ public final class KafkaRequestAPI<K, I, O> {
     }
 
     public CompletableFuture<O> queryResponse(final UUID requestId, final Duration timeout) {
-        // TODO - handle timeout...
+
         CompletableFuture<O> completableFuture = new CompletableFuture<>();
         ResponseHandler handler = responseHandlers.computeIfPresent(requestId, h -> {
             Optional<O> response = h.response;
@@ -157,7 +157,7 @@ public final class KafkaRequestAPI<K, I, O> {
                 completableFuture.complete(response.get());
             else {
                 ctx.scheduler().schedule(() -> {
-                    final TimeoutException ex = new TimeoutException("Timeout after " + timeout.toMillis() + " millis");
+                    final TimeoutException ex = new TimeoutException("Timeout after " + timeout);
                     completableFuture.complete(ctx.errorValue().apply(h.input, ex));
                 }, timeout.toMillis(), TimeUnit.MILLISECONDS);
                 h.responseFutures.add(completableFuture);

--- a/simplesource-data/pom.xml
+++ b/simplesource-data/pom.xml
@@ -39,8 +39,8 @@
 
         <dependency>
             <groupId>org.assertj</groupId>
-            <artifactId>assertj-core-java8</artifactId>
-            <version>1.0.0m1</version>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/simplesource-data/src/main/java/io/simplesource/data/Error.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/Error.java
@@ -1,0 +1,146 @@
+package io.simplesource.data;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A CommandError explains failures. They can be constructed from the reason type,
+ * with either a {@link String} or a {@link Throwable} for more context.
+ */
+public abstract class Error<Reason> {
+
+    /**
+     * Construct a {@link Error} from a {@link Throwable}.
+     *
+     * @param reason the reason value
+     * @param throwable for more context
+     * @return the constructed {@link Error}
+     */
+    public static <Reason> Error<Reason> of(final Reason reason, final Throwable throwable) {
+        return new ThrowableError<>(reason, throwable);
+    }
+
+    /**
+     * Construct a {@link Error} from a {@link Throwable}.
+     *
+     * @param reason the reason value
+     * @param msg for more context
+     * @return the constructed {@link Error}
+     */
+    public static <Reason> Error<Reason> of(final Reason reason, final String msg) {
+        return new StringError<>(reason, msg);
+    }
+
+    /**
+     * The reason value accessor.
+     *
+     * @return the reason
+     */
+    public Reason getReason() {
+        return reason;
+    }
+
+    /**
+     * The reason message accessor
+     *
+     * @return the reason message
+     */
+    public abstract String getMessage();
+
+    /**
+     * Access the reason value and either the string or the throwable context and return whatever you like.
+     *
+     * @param <A> the result type
+     * @param str the function that receives the reason and string, returning a value of the specified type
+     * @param ex the function that receives the reason and throwable, returning a value of the specified type
+     * @return the result
+     */
+    public abstract <A> A fold(BiFunction<Reason, String, A> str, BiFunction<Reason, Throwable, A> ex);
+
+    //
+    // internals
+    //
+
+    private final Reason reason;
+
+    private Error(final Reason reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public String toString() {
+        return "Error(" + fold(
+                (error, message) -> "Error: " + error + " Message: " + message,
+                (error, throwable) -> "Error: " + error + " Throwable: " + throwable) + ')';
+    }
+
+    static final class ThrowableError<Reason>  extends Error<Reason>  {
+        private final Throwable throwable;
+
+        ThrowableError(final Reason reason, final Throwable throwable) {
+            super(reason);
+            this.throwable = requireNonNull(throwable);
+        }
+
+        @Override
+        public String getMessage() {
+            return throwable.getMessage();
+        }
+
+        @Override
+        public <A> A fold(final BiFunction<Reason, String, A> str, final BiFunction<Reason, Throwable, A> ex) {
+            return ex.apply(getReason(), throwable);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * getReason().hashCode() + throwable.hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (!(obj instanceof ThrowableError))
+                return false;
+            final ThrowableError other = (ThrowableError) obj;
+            return Objects.equals(getReason(), other.getReason()) &&
+                    Objects.equals(throwable, other.throwable);
+        }
+
+    }
+
+    static final class StringError<Reason>  extends Error<Reason>  {
+        private final String msg;
+
+        StringError(final Reason reason, final String msg) {
+            super(reason);
+            this.msg = requireNonNull(msg);
+        }
+
+        @Override
+        public String getMessage() {
+            return msg;
+        }
+
+        @Override
+        public <A> A fold(final BiFunction<Reason, String, A> str, final BiFunction<Reason, Throwable, A> ex) {
+            return str.apply(getReason(), msg);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * getReason().hashCode() + msg.hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (!(obj instanceof StringError))
+                return false;
+            final StringError<?> other = (StringError<?>) obj;
+            return Objects.equals(getReason(), other.getReason()) &&
+                    Objects.equals(msg, other.msg);
+        }
+
+    }
+}

--- a/simplesource-data/src/main/java/io/simplesource/data/FutureResult.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/FutureResult.java
@@ -98,7 +98,11 @@ public final class FutureResult<E, T> {
         return new FutureResult<>(run.thenApply(r -> r.map(f)));
     }
 
-    public <R> Future<R> fold(Function<NonEmptyList<E>, R> e, Function<T, R> f) {
+    public <E2> FutureResult<E2, T> leftMap(Function<E, E2> f) {
+        return new FutureResult<>(run.thenApply(r -> r.leftMap(f)));
+    }
+
+    public <R> CompletableFuture<R> fold(Function<NonEmptyList<E>, R> e, Function<T, R> f) {
         return run.thenApply(r -> r.fold(e, f));
     }
 

--- a/simplesource-data/src/main/java/io/simplesource/data/FutureResult.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/FutureResult.java
@@ -98,8 +98,8 @@ public final class FutureResult<E, T> {
         return new FutureResult<>(run.thenApply(r -> r.map(f)));
     }
 
-    public <E2> FutureResult<E2, T> leftMap(Function<E, E2> f) {
-        return new FutureResult<>(run.thenApply(r -> r.leftMap(f)));
+    public <F> FutureResult<F, T> errorMap(Function<E, F> f) {
+        return new FutureResult<>(run.thenApply(r -> r.errorMap(f)));
     }
 
     public <R> CompletableFuture<R> fold(Function<NonEmptyList<E>, R> e, Function<T, R> f) {

--- a/simplesource-data/src/main/java/io/simplesource/data/NonEmptyList.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/NonEmptyList.java
@@ -24,15 +24,15 @@ public final class NonEmptyList<A> extends AbstractList<A> {
         return new NonEmptyList<>(a, Arrays.asList(as));
     }
 
-    public static <A> NonEmptyList<A> fromList(List<A> l) {
+    public static <A> Optional<NonEmptyList<A>> fromList(List<A> l) {
 
-        if (l.size() < 1) throw new IllegalStateException("Cannot create a NonEmptyList from an Empty List");
+        if (l.size() < 1) return Optional.empty();
 
         if (l.size() == 1) {
-            return NonEmptyList.of(l.get(0));
+            return Optional.of(NonEmptyList.of(l.get(0)));
         }
 
-        return new NonEmptyList<>(l.get(0), l.subList(1, l.size()));
+        return Optional.of(new NonEmptyList<>(l.get(0), l.subList(1, l.size())));
     }
 
     public NonEmptyList(final A head, final List<A> tail) {

--- a/simplesource-data/src/main/java/io/simplesource/data/NonEmptyList.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/NonEmptyList.java
@@ -1,9 +1,6 @@
 package io.simplesource.data;
 
-import java.util.AbstractList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -84,6 +81,13 @@ public final class NonEmptyList<A> extends AbstractList<A> {
 
     public List<A> tail() {
         return tail;
+    }
+
+    public List<A> toList() {
+        List<A> newList = new ArrayList<>();
+        newList.add(head);
+        newList.addAll(tail);
+        return newList;
     }
 
     public <B> B fold(final Function<A, B> initialResult, final BiFunction<B, A, B> op) {

--- a/simplesource-data/src/main/java/io/simplesource/data/Result.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/Result.java
@@ -134,7 +134,7 @@ public abstract class Result<E, A> {
      * @return a {@code Result<E, T>}
      * @throws NullPointerException if {@code mapper} is null
      */
-    public <F> Result<F, A> leftMap(final Function<E, F> errorMapper) {
+    public <F> Result<F, A> errorMap(final Function<E, F> errorMapper) {
         return fold(
                 errors -> failure(errors.map(errorMapper)),
                 a -> success(a)

--- a/simplesource-data/src/main/java/io/simplesource/data/Result.java
+++ b/simplesource-data/src/main/java/io/simplesource/data/Result.java
@@ -127,6 +127,21 @@ public abstract class Result<E, A> {
     }
 
     /**
+     * Modifies the error type of the result, returning a new {@code Result}
+     *
+     * @param <F>    The new component type
+     * @param errorMapper The error mapping function
+     * @return a {@code Result<E, T>}
+     * @throws NullPointerException if {@code mapper} is null
+     */
+    public <F> Result<F, A> leftMap(final Function<E, F> errorMapper) {
+        return fold(
+                errors -> failure(errors.map(errorMapper)),
+                a -> success(a)
+        );
+    }
+
+    /**
      * Runs the given function on the contents value this Result, returning a new {@code Result} with the
      * extracted reason extracted from the functions returned {@code Result<E, T>}
      *

--- a/simplesource-data/src/test/java/io/simplesource/data/FutureResultTest.java
+++ b/simplesource-data/src/test/java/io/simplesource/data/FutureResultTest.java
@@ -78,25 +78,25 @@ class FutureResultTest {
     }
 
     @Test
-    void leftMapShouldChangeTheErrorType() {
+    void errorMapShouldChangeTheErrorType() {
         FutureResult<TestError, Integer> futureResult = asynchronousFailure(futureResultReturnSignal,
                 FAILURE_COMMAND_ERROR_1, FAILURE_COMMAND_ERROR_2);
 
         triggerFutureResultReturnSignal();
 
         assertDoesNotThrow(() -> {
-            Result<TestError.Reason, Integer> actualResult = getFutureResultValue(futureResult.leftMap(TestError::getReason));
+            Result<TestError.Reason, Integer> actualResult = getFutureResultValue(futureResult.errorMap(TestError::getReason));
             assertThat(actualResult.isFailure()).isTrue();
             assertThat( actualResult.failureReasons().get()).containsOnly(TestError.Reason.InternalError, TestError.Reason.UnexpectedErrorCode);
         });
     }
 
     @Test
-    void leftMapShouldDoNothingOnSuccess() {
+    void errorMapShouldDoNothingOnSuccess() {
         FutureResult<TestError, Integer> futureResult = asynchronousSuccess(futureResultReturnSignal, 10);
 
         triggerFutureResultReturnSignal();
-        Result<TestError.Reason, Integer> result = getFutureResultValue(futureResult.leftMap(TestError::getReason));
+        Result<TestError.Reason, Integer> result = getFutureResultValue(futureResult.errorMap(TestError::getReason));
         assertThat(result.getOrElse(-1)).isEqualTo(10);
         assertTrue(result.isSuccess());
     }

--- a/simplesource-data/src/test/java/io/simplesource/data/FutureResultTest.java
+++ b/simplesource-data/src/test/java/io/simplesource/data/FutureResultTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FutureResultTest {
-    private static final int COUNTDOWN_SLEEP_TIME = 1000;
+    private static final int COUNTDOWN_SLEEP_TIME = 500;
     private static final String DEFAULT_VALUE = "not exist value";
     private static final TestError FAILURE_COMMAND_ERROR_1 = new TestError(TestError.Reason.InternalError);
     private static final TestError FAILURE_COMMAND_ERROR_2 = new TestError(TestError.Reason.UnexpectedErrorCode);
@@ -78,6 +78,30 @@ class FutureResultTest {
     }
 
     @Test
+    void leftMapShouldChangeTheErrorType() {
+        FutureResult<TestError, Integer> futureResult = asynchronousFailure(futureResultReturnSignal,
+                FAILURE_COMMAND_ERROR_1, FAILURE_COMMAND_ERROR_2);
+
+        triggerFutureResultReturnSignal();
+
+        assertDoesNotThrow(() -> {
+            Result<TestError.Reason, Integer> actualResult = getFutureResultValue(futureResult.leftMap(TestError::getReason));
+            assertThat(actualResult.isFailure()).isTrue();
+            assertThat( actualResult.failureReasons().get()).containsOnly(TestError.Reason.InternalError, TestError.Reason.UnexpectedErrorCode);
+        });
+    }
+
+    @Test
+    void leftMapShouldDoNothingOnSuccess() {
+        FutureResult<TestError, Integer> futureResult = asynchronousSuccess(futureResultReturnSignal, 10);
+
+        triggerFutureResultReturnSignal();
+        Result<TestError.Reason, Integer> result = getFutureResultValue(futureResult.leftMap(TestError::getReason));
+        assertThat(result.getOrElse(-1)).isEqualTo(10);
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
     void flatMapShouldMapIntValueToStringWhenFutureResultIsSuccess() {
         FutureResult<TestError, Integer> futureResult = asynchronousSuccess(futureResultReturnSignal, 10);
 
@@ -137,7 +161,7 @@ class FutureResultTest {
         );
     }
 
-    private static <T> Result<TestError, T> getFutureResultValue(FutureResult<TestError, T> futureResult) {
+    private static <E, T> Result<E, T> getFutureResultValue(FutureResult<E, T> futureResult) {
         return futureResult.future().join();
     }
 }

--- a/simplesource-data/src/test/java/io/simplesource/data/NonEmptyListTest.java
+++ b/simplesource-data/src/test/java/io/simplesource/data/NonEmptyListTest.java
@@ -49,6 +49,13 @@ class NonEmptyListTest {
     }
 
     @Test
+    void toListShouldReturnAllElementsOfList() {
+        NonEmptyList<Integer> list = NonEmptyList.of(10, 20, 30, 40);
+
+        assertThat(list.toList()).containsExactly(10, 20, 30, 40);
+    }
+
+    @Test
     void lastShouldReturnLastElementOfList() {
         NonEmptyList<Integer> list = NonEmptyList.of(10, 20, 30, 40);
 

--- a/simplesource-data/src/test/java/io/simplesource/data/NonEmptyListTest.java
+++ b/simplesource-data/src/test/java/io/simplesource/data/NonEmptyListTest.java
@@ -3,6 +3,7 @@ package io.simplesource.data;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -82,13 +83,16 @@ class NonEmptyListTest {
 
     @Test
     void fromListShouldCreateNonEmptyListFromElementsInTheSameOrder() {
-        NonEmptyList<Integer> list = NonEmptyList.fromList(Stream.of(100, 10, 5).collect(toList()));
+        Optional<NonEmptyList<Integer>> oList = NonEmptyList.fromList(Stream.of(100, 10, 5).collect(toList()));
 
-        assertThat(list).containsExactly(100, 10, 5);
+        assertThat(oList.isPresent()).isTrue();
+        oList.ifPresent(list -> assertThat(list).containsExactly(100, 10, 5));
     }
 
     @Test
-    void fromListShouldThrowIllegalStateExceptionWhenListIsEmpty() {
-        assertThrows(IllegalStateException.class, () -> NonEmptyList.fromList(new ArrayList<>()));
+    void fromListShouldNotCreateNELFromEmptyList() {
+        Optional<NonEmptyList<Integer>> oList = NonEmptyList.fromList(new ArrayList<>());
+
+        assertThat(oList.isPresent()).isFalse();
     }
 }


### PR DESCRIPTION
* Extracted a generic `Error` implementation. This is now used internally by `CommandError`.
* Added an `errorMap` method to `Result`. This is effectively a leftMap, making it easy to change the error type.
* `FutureResult.fold` now returns a `CompletableFuture`.
* `NonEmptyList.fromList` now returns `Optional<NonEmptyList>`, instead of throwing an error.
* Added a `toList` method to `NonEmptyList`