### PR TITLE
Command id non guid

### DIFF
--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandAPI.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandAPI.java
@@ -5,7 +5,6 @@ import io.simplesource.data.Sequence;
 import lombok.Value;
 
 import java.time.Duration;
-import java.util.UUID;
 
 /**
  * The public API for submitting commands against a given aggregate and

--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandAPI.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandAPI.java
@@ -28,7 +28,7 @@ public interface CommandAPI<K, C> {
      * @return a <code>FutureResult</code> with the commandId echoed back if the command was successfully queued,
      * otherwise a list of reasons for the failure.
      */
-    FutureResult<CommandError, UUID> publishCommand(Request<K, C> request);
+    FutureResult<CommandError, CommandId> publishCommand(Request<K, C> request);
 
     /**
      * Get the result of the execution of the command identified by the provided UUID.
@@ -39,12 +39,12 @@ public interface CommandAPI<K, C> {
      * If a command is queried outside the retention window it will keep trying for the
      * given timeout duration then fail with a <code>Timeout</code> error code.
      *
-     * @param commandId the UUID of the command to lookup the result for.
+     * @param commandId the CommandId of the command to lookup the result for.
      * @param timeout how long to wait attempting to fetch the result before timing out.
      * @return sequence number of aggregate.
      */
     FutureResult<CommandError, Sequence> queryCommandResult(
-        UUID commandId,
+        CommandId commandId,
         Duration timeout
     );
 
@@ -69,7 +69,7 @@ public interface CommandAPI<K, C> {
         // the version of the aggregate this command is based on
         private final Sequence readSequence;
         // unique id for this command
-        private final UUID commandId;
+        private final CommandId commandId;
         // the command we wish to apply to the aggregate
         private final C command;
     }

--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandId.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandId.java
@@ -5,6 +5,6 @@ import lombok.Value;
 import java.util.UUID;
 
 @Value(staticConstructor = "of")
-public final class CommandId implements UuidId {
+public final class CommandId {
     private final UUID id;
 }

--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandId.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandId.java
@@ -1,0 +1,10 @@
+package io.simplesource.api;
+
+import lombok.Value;
+
+import java.util.UUID;
+
+@Value(staticConstructor = "of")
+public final class CommandId implements UuidId {
+    private final UUID id;
+}

--- a/simplesource-command-api/src/main/java/io/simplesource/api/CommandId.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/CommandId.java
@@ -6,5 +6,9 @@ import java.util.UUID;
 
 @Value(staticConstructor = "of")
 public final class CommandId {
-    private final UUID id;
+    public final UUID id;
+
+    public static CommandId random() {
+        return new CommandId(UUID.randomUUID());
+    }
 }

--- a/simplesource-command-api/src/main/java/io/simplesource/api/UuidId.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/UuidId.java
@@ -1,0 +1,7 @@
+package io.simplesource.api;
+
+import java.util.UUID;
+
+public interface UuidId {
+     UUID id();
+}

--- a/simplesource-command-api/src/main/java/io/simplesource/api/UuidId.java
+++ b/simplesource-command-api/src/main/java/io/simplesource/api/UuidId.java
@@ -1,7 +1,0 @@
-package io.simplesource.api;
-
-import java.util.UUID;
-
-public interface UuidId {
-     UUID id();
-}

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/api/CommandSerdes.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/api/CommandSerdes.java
@@ -1,10 +1,9 @@
 package io.simplesource.kafka.api;
 
+import io.simplesource.api.CommandId;
 import io.simplesource.kafka.model.CommandRequest;
 import io.simplesource.kafka.model.CommandResponse;
 import org.apache.kafka.common.serialization.Serde;
-
-import java.util.UUID;
 
 /**
  * Responsible for providing the mechanism for reading and writing to Kafka from the Simple Sourcing
@@ -18,6 +17,6 @@ import java.util.UUID;
 public interface CommandSerdes<K, C> {
     Serde<K> aggregateKey();
     Serde<CommandRequest<K, C>> commandRequest();
-    Serde<UUID> commandResponseKey();
+    Serde<CommandId> commandResponseKey();
     Serde<CommandResponse<K>> commandResponse();
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
@@ -62,7 +62,7 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
     @Override
     public FutureResult<CommandError, CommandId> publishCommand(final Request<K, C> request) {
         final CommandRequest<K, C> commandRequest = new CommandRequest<>(
-                request.key(), request.command(), request.readSequence(), request.commandId());
+                request.commandId(), request.key(), request.readSequence(), request.command());
 
         FutureResult<Exception, RequestPublisher.PublishResult> publishResult = requestApi.publishRequest(request.key(), request.commandId(), commandRequest);
 
@@ -106,8 +106,8 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
                 .scheduler(scheduler)
                 .errorValue((i, e) ->
                         new CommandResponse(
-                                i.aggregateKey(),
                                 i.commandId(),
+                                i.aggregateKey(),
                                 i.readSequence(),
                                 Result.failure(getCommandError(e))))
                 .build();

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
@@ -14,7 +14,6 @@ import io.simplesource.kafka.model.CommandResponse;
 import io.simplesource.kafka.spec.CommandSpec;
 
 import java.time.Duration;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaRequestAPI.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaRequestAPI.java
@@ -2,7 +2,6 @@ package io.simplesource.kafka.internal.client;
 
 import io.simplesource.data.FutureResult;
 import io.simplesource.kafka.dsl.KafkaConfig;
-import io.simplesource.api.UuidId;
 import io.simplesource.kafka.spec.TopicSpec;
 import lombok.Value;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -25,7 +24,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public final class KafkaRequestAPI<K, I, RK extends UuidId, R> {
+public final class KafkaRequestAPI<K, I, RK, R> {
     private static final Logger logger = LoggerFactory.getLogger(KafkaRequestAPI.class);
 
     @Value
@@ -91,7 +90,7 @@ public final class KafkaRequestAPI<K, I, RK extends UuidId, R> {
                     ctx.privateResponseTopic(),
                     ctx.responseValueSerde(),
                     receiver,
-                    ctx.idConverter()),
+                    ctx.uuidToResponseId()),
                 true);
     }
 

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/RequestAPIContext.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/RequestAPIContext.java
@@ -15,7 +15,7 @@ import java.util.function.Function;
 
 @Value
 @Builder
-public final class RequestAPIContext<K, I, RK extends UuidId, O> {
+public final class RequestAPIContext<K, I, RK extends UuidId, R> {
     final KafkaConfig kafkaConfig;
     final ScheduledExecutorService scheduler;
     final String requestTopic;
@@ -24,9 +24,9 @@ public final class RequestAPIContext<K, I, RK extends UuidId, O> {
     final Serde<K> requestKeySerde;
     final Serde<I> requestValueSerde;
     final Serde<RK> responseKeySerde;
-    final Serde<O> responseValueSerde;
+    final Serde<R> responseValueSerde;
     final WindowSpec responseWindowSpec;
     final TopicSpec outputTopicConfig;
-    final BiFunction<I, Throwable, O> errorValue;
+    final BiFunction<I, Throwable, R> errorValue;
     final Function<UUID, RK> idConverter;
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/RequestAPIContext.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/RequestAPIContext.java
@@ -1,7 +1,6 @@
 package io.simplesource.kafka.internal.client;
 
 import io.simplesource.kafka.dsl.KafkaConfig;
-import io.simplesource.api.UuidId;
 import io.simplesource.kafka.spec.TopicSpec;
 import io.simplesource.kafka.spec.WindowSpec;
 import lombok.Builder;
@@ -15,7 +14,7 @@ import java.util.function.Function;
 
 @Value
 @Builder
-public final class RequestAPIContext<K, I, RK extends UuidId, R> {
+public final class RequestAPIContext<K, I, RK, R> {
     final KafkaConfig kafkaConfig;
     final ScheduledExecutorService scheduler;
     final String requestTopic;
@@ -28,5 +27,6 @@ public final class RequestAPIContext<K, I, RK extends UuidId, R> {
     final WindowSpec responseWindowSpec;
     final TopicSpec outputTopicConfig;
     final BiFunction<I, Throwable, R> errorValue;
-    final Function<UUID, RK> idConverter;
+    final Function<UUID, RK> uuidToResponseId;
+    final Function<RK, UUID> responseIdToUuid;
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/RequestAPIContext.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/RequestAPIContext.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.internal.client;
 
 import io.simplesource.kafka.dsl.KafkaConfig;
+import io.simplesource.api.UuidId;
 import io.simplesource.kafka.spec.TopicSpec;
 import io.simplesource.kafka.spec.WindowSpec;
 import lombok.Builder;
@@ -10,10 +11,11 @@ import org.apache.kafka.common.serialization.Serde;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 @Value
 @Builder
-public final class RequestAPIContext<K, I, O> {
+public final class RequestAPIContext<K, I, RK extends UuidId, O> {
     final KafkaConfig kafkaConfig;
     final ScheduledExecutorService scheduler;
     final String requestTopic;
@@ -21,9 +23,10 @@ public final class RequestAPIContext<K, I, O> {
     final String privateResponseTopic;
     final Serde<K> requestKeySerde;
     final Serde<I> requestValueSerde;
-    final Serde<UUID> responseKeySerde;
+    final Serde<RK> responseKeySerde;
     final Serde<O> responseValueSerde;
     final WindowSpec responseWindowSpec;
     final TopicSpec outputTopicConfig;
     final BiFunction<I, Throwable, O> errorValue;
+    final Function<UUID, RK> idConverter;
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/AggregateUpdateResult.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/AggregateUpdateResult.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Sequence;
 import io.simplesource.data.Result;
 import io.simplesource.kafka.model.AggregateUpdate;
@@ -12,7 +13,7 @@ import java.util.UUID;
 @Value
 @AllArgsConstructor
 final class AggregateUpdateResult<A> {
-    private UUID commandId;
+    private CommandId commandId;
     private Sequence readSequence;
     private Result<CommandError, AggregateUpdate<A>> updatedAggregateResult;
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/CommandEvents.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/CommandEvents.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Sequence;
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
@@ -17,7 +18,7 @@ import java.util.UUID;
 @Value
 @AllArgsConstructor
 final class CommandEvents<E, A> {
-    private final UUID commandId;
+    private final CommandId commandId;
     private final Sequence readSequence;
     private final A aggregate;
     private final Result<CommandError, NonEmptyList<ValueWithSequence<E>>> eventValue;

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/CommandEvents.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/CommandEvents.java
@@ -9,8 +9,6 @@ import io.simplesource.kafka.model.ValueWithSequence;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
-import java.util.UUID;
-
 /**
  * @param <E> all events generated for this aggregate
  * @param <A> the aggregate aggregate_update

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/EventSourcedStreams.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/EventSourcedStreams.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Result;
 import io.simplesource.kafka.internal.util.Tuple2;
 import io.simplesource.kafka.model.*;
@@ -13,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.UUID;
 import java.util.function.BiFunction;
 
 final class EventSourcedStreams {
@@ -28,7 +28,7 @@ final class EventSourcedStreams {
             final KStream<K, CommandRequest<K, C>> commandRequestStream,
             final KStream<K, CommandResponse<K>> commandResponseStream) {
 
-        final KTable<UUID, CommandResponse<K>> commandResponseById = commandResponseStream
+        final KTable<CommandId, CommandResponse<K>> commandResponseById = commandResponseStream
                 .selectKey((key, response) -> response.commandId())
                 .groupByKey(Serialized.with(ctx.serdes().commandResponseKey(), ctx.serdes().commandResponse()))
                 .reduce((r1, r2) -> getResponseSequence(r1) > getResponseSequence(r2) ? r1 : r2);

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/EventSourcedStreams.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/EventSourcedStreams.java
@@ -101,7 +101,7 @@ final class EventSourcedStreams {
     static <K, A>  KStream<K, CommandResponse<K>> getCommandResponses(final KStream<K, AggregateUpdateResult<A>> aggregateUpdateStream) {
         return aggregateUpdateStream
                 .mapValues((key, update) ->
-                        new CommandResponse<>(key, update.commandId(), update.readSequence(), update.updatedAggregateResult().map(AggregateUpdate::sequence))
+                        new CommandResponse<>(update.commandId(), key, update.readSequence(), update.updatedAggregateResult().map(AggregateUpdate::sequence))
                 );
     }
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/EventSourcedTopology.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/EventSourcedTopology.java
@@ -57,7 +57,7 @@ public final class EventSourcedTopology {
                 ctx.aggregateSpec().serialization().resourceNamingStrategy().topicName(ctx.aggregateSpec().aggregateName(), AggregateResources.TopicEntity.command_response_topic_map.toString()),
                 new DistributorSerdes<>(ctx.serdes().commandResponseKey(), ctx.serdes().commandResponse()),
                 ctx.aggregateSpec().generation().stateStoreSpec(),
-                CommandResponse::commandId);
+                CommandResponse::commandId, CommandId::id);
     }
 }
 

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/ResultDistributor.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/ResultDistributor.java
@@ -1,7 +1,6 @@
 package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.kafka.internal.util.Tuple2;
-import io.simplesource.api.UuidId;
 import io.simplesource.kafka.spec.WindowSpec;
 import lombok.Value;
 import org.apache.kafka.common.serialization.Serde;
@@ -10,29 +9,31 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.*;
 
+import java.util.UUID;
 import java.util.function.Function;
 
 @Value
-final class DistributorSerdes<K extends UuidId, V> {
+final class DistributorSerdes<K, V> {
     Serde<K> uuid;
     Serde<V> value;
 }
 
 @Value
-final class DistributorContext<K extends UuidId, V> {
+final class DistributorContext<K, V> {
     public final String topicNameMapTopic;
     public final DistributorSerdes<K, V> serdes;
     private final WindowSpec responseWindowSpec;
     public final Function<V, K> idMapper;
+    public final Function<K, UUID> keyToUuid;
 }
 
 final class ResultDistributor {
 
-    static <K extends UuidId> KStream<K, String> resultTopicMapStream(DistributorContext<K, ?> ctx, final StreamsBuilder builder) {
+    static <K> KStream<K, String> resultTopicMapStream(DistributorContext<K, ?> ctx, final StreamsBuilder builder) {
         return builder.stream(ctx.topicNameMapTopic, Consumed.with(ctx.serdes().uuid(), Serdes.String()));
     }
 
-    static <K extends UuidId, V> void distribute(DistributorContext<K, V> ctx, final KStream<?, V> resultStream, final KStream<K, String> topicNameStream) {
+    static <K, V> void distribute(DistributorContext<K, V> ctx, final KStream<?, V> resultStream, final KStream<K, String> topicNameStream) {
 
         DistributorSerdes<K, V> serdes = ctx.serdes();
         long retentionMillis = ctx.responseWindowSpec().retentionInSeconds() * 1000L;
@@ -42,7 +43,7 @@ final class ResultDistributor {
                         Tuple2::of,
                         JoinWindows.of(retentionMillis).until(retentionMillis * 2 + 1),
                         Joined.with(serdes.uuid(), serdes.value(), Serdes.String()))
-                .map((uuid, tuple) -> KeyValue.pair(String.format("%s:%s", tuple.v2(), uuid.id().toString()), tuple.v1()));
+                .map((uuid, tuple) -> KeyValue.pair(String.format("%s:%s", tuple.v2(), ctx.keyToUuid.apply(uuid).toString()), tuple.v1()));
 
         joined.to((key, value, context) -> key.substring(0, key.length() - 37), Produced.with(Serdes.String(), serdes.value()));
     }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/ResultDistributor.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/ResultDistributor.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.kafka.internal.util.Tuple2;
+import io.simplesource.api.UuidId;
 import io.simplesource.kafka.spec.WindowSpec;
 import lombok.Value;
 import org.apache.kafka.common.serialization.Serde;
@@ -9,40 +10,39 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.*;
 
-import java.util.UUID;
 import java.util.function.Function;
 
 @Value
-final class DistributorSerdes<V> {
-    Serde<UUID> uuid;
+final class DistributorSerdes<K extends UuidId, V> {
+    Serde<K> uuid;
     Serde<V> value;
 }
 
 @Value
-final class DistributorContext<V> {
+final class DistributorContext<K extends UuidId, V> {
     public final String topicNameMapTopic;
-    public final DistributorSerdes<V> serdes;
+    public final DistributorSerdes<K, V> serdes;
     private final WindowSpec responseWindowSpec;
-    public final Function<V, UUID> idMapper;
+    public final Function<V, K> idMapper;
 }
 
 final class ResultDistributor {
 
-    static KStream<UUID, String> resultTopicMapStream(DistributorContext<?> ctx, final StreamsBuilder builder) {
+    static <K extends UuidId> KStream<K, String> resultTopicMapStream(DistributorContext<K, ?> ctx, final StreamsBuilder builder) {
         return builder.stream(ctx.topicNameMapTopic, Consumed.with(ctx.serdes().uuid(), Serdes.String()));
     }
 
-    static <V> void distribute(DistributorContext<V> ctx, final KStream<?, V> resultStream, final KStream<UUID, String> topicNameStream) {
+    static <K extends UuidId, V> void distribute(DistributorContext<K, V> ctx, final KStream<?, V> resultStream, final KStream<K, String> topicNameStream) {
 
-        DistributorSerdes<V> serdes = ctx.serdes();
+        DistributorSerdes<K, V> serdes = ctx.serdes();
         long retentionMillis = ctx.responseWindowSpec().retentionInSeconds() * 1000L;
 
         KStream<String, V> joined = resultStream.selectKey((k, v) -> ctx.idMapper.apply(v))
                 .join(topicNameStream,
-                        Tuple2::new,
+                        Tuple2::of,
                         JoinWindows.of(retentionMillis).until(retentionMillis * 2 + 1),
                         Joined.with(serdes.uuid(), serdes.value(), Serdes.String()))
-                .map((uuid, tuple) -> KeyValue.pair(String.format("%s:%s", tuple.v2(), uuid.toString()), tuple.v1()));
+                .map((uuid, tuple) -> KeyValue.pair(String.format("%s:%s", tuple.v2(), uuid.id().toString()), tuple.v1()));
 
         joined.to((key, value, context) -> key.substring(0, key.length() - 37), Produced.with(Serdes.String(), serdes.value()));
     }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/TopologyContext.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/streams/topology/TopologyContext.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.api.Aggregator;
+import io.simplesource.api.CommandId;
 import io.simplesource.api.InitialValue;
 import io.simplesource.kafka.api.AggregateResources;
 import io.simplesource.kafka.api.AggregateSerdes;
@@ -11,8 +12,6 @@ import lombok.Value;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Serialized;
-
-import java.util.UUID;
 
 /**
  * @param <A> the aggregate aggregate_update
@@ -34,7 +33,7 @@ public final class TopologyContext<K, C, E, A> {
     final Produced<K, ValueWithSequence<E>> eventsConsumedProduced;
     final Produced<K, AggregateUpdate<A>> aggregatedUpdateProduced;
     final Produced<K, CommandResponse<K>> commandResponseProduced;
-    final Serialized<UUID, CommandResponse<K>> serializedCommandResponse;
+    final Serialized<CommandId, CommandResponse<K>> serializedCommandResponse;
 
     public TopologyContext(AggregateSpec<K, C, E, A> aggregateSpec) {
         this.aggregateSpec = aggregateSpec;

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandRequest.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandRequest.java
@@ -1,9 +1,9 @@
 package io.simplesource.kafka.model;
 
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Sequence;
 import lombok.Value;
 
-import java.util.UUID;
 import java.util.function.Function;
 
 /**
@@ -15,7 +15,7 @@ public final class CommandRequest<K, C> {
     private final K aggregateKey;
     private final C command;
     private final Sequence readSequence;
-    private final UUID commandId;
+    private final CommandId commandId;
 
     public <KR, CR> CommandRequest<KR, CR> map2(final Function<K, KR> fk, final Function<C, CR> fc) {
         return new CommandRequest<>(fk.apply(aggregateKey), fc.apply(command), readSequence, commandId);

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandRequest.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandRequest.java
@@ -12,12 +12,12 @@ import java.util.function.Function;
  */
 @Value
 public final class CommandRequest<K, C> {
+    private CommandId commandId;
     private final K aggregateKey;
+    private Sequence readSequence;
     private final C command;
-    private final Sequence readSequence;
-    private final CommandId commandId;
 
     public <KR, CR> CommandRequest<KR, CR> map2(final Function<K, KR> fk, final Function<C, CR> fc) {
-        return new CommandRequest<>(fk.apply(aggregateKey), fc.apply(command), readSequence, commandId);
+        return new CommandRequest<>(commandId, fk.apply(aggregateKey), readSequence, fc.apply(command));
     }
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandResponse.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandResponse.java
@@ -13,12 +13,12 @@ import java.util.function.Function;
 @Value
 @AllArgsConstructor
 public final class CommandResponse<K> {
-    private final K aggregateKey;
     private CommandId commandId;
+    private final K aggregateKey;
     private Sequence readSequence;
     private Result<CommandError, Sequence> sequenceResult;
 
     public <KR> CommandResponse<KR> map(final Function<K, KR> fk) {
-        return new CommandResponse<>(fk.apply(aggregateKey), commandId, readSequence, sequenceResult);
+        return new CommandResponse<>(commandId, fk.apply(aggregateKey), readSequence, sequenceResult);
     }
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandResponse.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandResponse.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.model;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
 import lombok.AllArgsConstructor;
@@ -13,7 +14,7 @@ import java.util.function.Function;
 @AllArgsConstructor
 public final class CommandResponse<K> {
     private final K aggregateKey;
-    private UUID commandId;
+    private CommandId commandId;
     private Sequence readSequence;
     private Result<CommandError, Sequence> sequenceResult;
 

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandResponse.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/model/CommandResponse.java
@@ -7,7 +7,6 @@ import io.simplesource.data.Sequence;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
-import java.util.UUID;
 import java.util.function.Function;
 
 @Value

--- a/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/EventSourcedTopologyTest.java
+++ b/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/EventSourcedTopologyTest.java
@@ -239,7 +239,8 @@ class EventSourcedTopologyTest {
                     topicNamesTopic,
                     new DistributorSerdes<>(ctx.serdes().commandResponseKey(), ctx.serdes().commandResponse()),
                     ctx.aggregateSpec().generation().stateStoreSpec(),
-                    CommandResponse::commandId);
+                    CommandResponse::commandId,
+                    CommandId::id);
 
             KStream<CommandId, String> topicNames = builder.stream(topicNamesTopic, Consumed.with(ctx.serdes().commandResponseKey(), Serdes.String()));
             ResultDistributor.distribute(context, inputStreams.commandResponse, topicNames);

--- a/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/EventSourcedTopologyTest.java
+++ b/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/EventSourcedTopologyTest.java
@@ -64,7 +64,7 @@ class EventSourcedTopologyTest {
         TestContextDriver<String, TestCommand, TestEvent, Optional<TestAggregate>> ctxDriver = new TestContextDriver<>(ctx, driver);
 
         CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                key, new TestCommand.CreateCommand("Name"), Sequence.first().next(), CommandId.of(UUID.randomUUID()));
+                CommandId.of(UUID.randomUUID()), key, Sequence.first().next(), new TestCommand.CreateCommand("Name"));
 
         ctxDriver.publishCommand( key, commandRequest);
         ctxDriver.verifyCommandResponse(key, r -> {
@@ -84,7 +84,7 @@ class EventSourcedTopologyTest {
         TestContextDriver<String, TestCommand, TestEvent, Optional<TestAggregate>> ctxDriver = new TestContextDriver<>(ctx, driver);
 
         CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                key, new TestCommand.UnsupportedCommand(), Sequence.first(), CommandId.of(UUID.randomUUID()));
+                CommandId.of(UUID.randomUUID()), key, Sequence.first(), new TestCommand.UnsupportedCommand());
 
         ctxDriver.publishCommand( key, commandRequest);
         ctxDriver.verifyCommandResponse(key, r -> {
@@ -105,7 +105,7 @@ class EventSourcedTopologyTest {
 
         String name = "name";
         CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                key, new TestCommand.CreateCommand(name), Sequence.first(), CommandId.of(UUID.randomUUID()));
+                CommandId.of(UUID.randomUUID()), key, Sequence.first(), new TestCommand.CreateCommand(name));
 
         ctxDriver.publishCommand( key, commandRequest);
         ctxDriver.verifyCommandResponse(key, v -> {
@@ -135,7 +135,7 @@ class EventSourcedTopologyTest {
         TestContextDriver<String, TestCommand, TestEvent, Optional<TestAggregate>> ctxDriver = new TestContextDriver<>(ctx, driver);
 
         ctxDriver.publishCommand( key, new CommandRequest<>(
-                key, new TestCommand.CreateCommand("firstName"), Sequence.first(), CommandId.of(UUID.randomUUID())));
+                CommandId.of(UUID.randomUUID()), key, Sequence.first(), new TestCommand.CreateCommand("firstName")));
         ctxDriver.verifyAggregateUpdate(key, null);
         CommandResponse<String> response = ctxDriver.verifyCommandResponse(key, null);
         ctxDriver.verifyEvents(key, null);
@@ -144,7 +144,7 @@ class EventSourcedTopologyTest {
             String newName = String.format("firstName %d", i);
             Sequence lastSequence = response.sequenceResult().getOrElse(Sequence.first());
             CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                    key, new TestCommand.UpdateWithNothingCommand(newName), lastSequence, CommandId.of(UUID.randomUUID()));
+                    CommandId.of(UUID.randomUUID()), key, lastSequence, new TestCommand.UpdateWithNothingCommand(newName));
             ctxDriver.publishCommand(key, commandRequest);
 
             List<ValueWithSequence<TestEvent>> events = ctxDriver.verifyEvents(key, iV -> {
@@ -186,7 +186,7 @@ class EventSourcedTopologyTest {
         TestContextDriver<String, TestCommand, TestEvent, Optional<TestAggregate>> ctxDriver = new TestContextDriver<>(ctx, driver);
 
         CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                key, new TestCommand.CreateCommand("Name 2"), Sequence.position(1000), CommandId.of(UUID.randomUUID()));
+                CommandId.of(UUID.randomUUID()), key, Sequence.position(1000), new TestCommand.CreateCommand("Name 2"));
 
         ctxDriver.publishCommand( key, commandRequest);
         ctxDriver.verifyCommandResponse(key, r -> {
@@ -205,7 +205,7 @@ class EventSourcedTopologyTest {
         TestContextDriver<String, TestCommand, TestEvent, Optional<TestAggregate>> ctxDriver = new TestContextDriver<>(ctx, driver);
 
         CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                key, new TestCommand.CreateCommand("Name"), Sequence.first(), CommandId.of(UUID.randomUUID()));
+                CommandId.of(UUID.randomUUID()), key, Sequence.first(), new TestCommand.CreateCommand("Name"));
 
         ctxDriver.publishCommand( key, commandRequest);
 
@@ -247,7 +247,7 @@ class EventSourcedTopologyTest {
         TestContextDriver<String, TestCommand, TestEvent, Optional<TestAggregate>> ctxDriver = new TestContextDriver<>(ctx, driver);
 
         CommandRequest<String, TestCommand> commandRequest = new CommandRequest<>(
-                key, new TestCommand.CreateCommand("Name 2"), Sequence.first(), CommandId.of(UUID.randomUUID()));
+                CommandId.of(UUID.randomUUID()), key, Sequence.first(), new TestCommand.CreateCommand("Name 2"));
 
         ctxDriver.getPublisher(ctx.serdes().commandResponseKey(), Serdes.String())
                 .publish(topicNamesTopic, commandRequest.commandId(), outputTopic);
@@ -257,7 +257,7 @@ class EventSourcedTopologyTest {
                 Serdes.String().deserializer(),
                 ctx.serdes().commandResponse().deserializer());
 
-        assertThat(output.key()).isEqualTo(String.format("%s:%s", outputTopic, commandRequest.commandId().toString()));
+        assertThat(output.key()).isEqualTo(String.format("%s:%s", outputTopic, commandRequest.commandId().id().toString()));
         assertThat(output.value().sequenceResult().isSuccess()).isEqualTo(true);
     }
 }

--- a/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/TestContextBuilder.java
+++ b/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/TestContextBuilder.java
@@ -2,6 +2,7 @@ package io.simplesource.kafka.internal.streams.topology;
 
 import io.simplesource.api.Aggregator;
 import io.simplesource.api.CommandHandler;
+import io.simplesource.api.CommandId;
 import io.simplesource.api.InitialValue;
 import io.simplesource.kafka.api.AggregateResources;
 import io.simplesource.kafka.api.AggregateSerdes;
@@ -96,7 +97,7 @@ class TestContextBuilder {
             }
 
             @Override
-            public Serde<UUID> commandResponseKey() {
+            public Serde<CommandId> commandResponseKey() {
                 return new MockInMemorySerde<>();
             }
 

--- a/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/TestContextBuilder.java
+++ b/simplesource-command-kafka/src/test/java/io/simplesource/kafka/internal/streams/topology/TestContextBuilder.java
@@ -9,19 +9,21 @@ import io.simplesource.kafka.api.AggregateSerdes;
 import io.simplesource.kafka.dsl.AggregateBuilder;
 import io.simplesource.kafka.dsl.InvalidSequenceStrategy;
 import io.simplesource.kafka.internal.streams.MockInMemorySerde;
-import io.simplesource.kafka.util.PrefixResourceNamingStrategy;
 import io.simplesource.kafka.internal.streams.model.TestAggregate;
 import io.simplesource.kafka.internal.streams.model.TestCommand;
 import io.simplesource.kafka.internal.streams.model.TestEvent;
-import io.simplesource.kafka.model.*;
+import io.simplesource.kafka.model.AggregateUpdate;
+import io.simplesource.kafka.model.CommandRequest;
+import io.simplesource.kafka.model.CommandResponse;
+import io.simplesource.kafka.model.ValueWithSequence;
 import io.simplesource.kafka.spec.TopicSpec;
+import io.simplesource.kafka.util.PrefixResourceNamingStrategy;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.UUID;
 
 class TestContextBuilder {
 

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroAggregateSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroAggregateSerdes.java
@@ -1,5 +1,6 @@
 package io.simplesource.kafka.serialization.avro;
 
+import io.simplesource.api.CommandId;
 import io.simplesource.kafka.api.AggregateSerdes;
 import io.simplesource.kafka.serialization.util.GenericMapper;
 import io.simplesource.kafka.model.*;
@@ -18,7 +19,7 @@ public final class AvroAggregateSerdes<K, C, E, A> implements AggregateSerdes<K,
 
     private final Serde<K> ak;
     private final Serde<CommandRequest<K, C>> crq;
-    private final Serde<UUID> crk;
+    private final Serde<CommandId> crk;
     private final Serde<ValueWithSequence<E>> vws;
     private final Serde<AggregateUpdate<A>> au;
     private final Serde<CommandResponse<K>> crp;
@@ -96,7 +97,7 @@ public final class AvroAggregateSerdes<K, C, E, A> implements AggregateSerdes<K,
     }
 
     @Override
-    public Serde<UUID> commandResponseKey() {
+    public Serde<CommandId> commandResponseKey() {
         return crk;
     }
 

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroCommandSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroCommandSerdes.java
@@ -11,7 +11,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.common.serialization.Serde;
 
 import java.util.Arrays;
-import java.util.UUID;
 
 import static io.simplesource.kafka.serialization.avro.AvroSpecificGenericMapper.specificDomainMapper;
 

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroCommandSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroCommandSerdes.java
@@ -1,5 +1,6 @@
 package io.simplesource.kafka.serialization.avro;
 
+import io.simplesource.api.CommandId;
 import io.simplesource.kafka.api.CommandSerdes;
 import io.simplesource.kafka.model.CommandRequest;
 import io.simplesource.kafka.model.CommandResponse;
@@ -18,7 +19,7 @@ public final class AvroCommandSerdes<K, C> implements CommandSerdes<K, C> {
 
     private final Serde<K> ak;
     private final Serde<CommandRequest<K, C>> crq;
-    private final Serde<UUID> crk;
+    private final Serde<CommandId> crk;
     private final Serde<CommandResponse<K>> crp;
 
     public static <K extends GenericRecord, C extends GenericRecord> AvroCommandSerdes<K, C> of(
@@ -83,7 +84,7 @@ public final class AvroCommandSerdes<K, C> implements CommandSerdes<K, C> {
     }
 
     @Override
-    public Serde<UUID> commandResponseKey() {
+    public Serde<CommandId> commandResponseKey() {
         return crk;
     }
 

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/avro/AvroSerdes.java
@@ -44,7 +44,7 @@ public final class AvroSerdes {
             return builder
                     .set(AGGREGATE_KEY, commandRequest.aggregateKey())
                     .set(READ_SEQUENCE, commandRequest.readSequence().getSeq())
-                    .set(COMMAND_ID, commandRequest.commandId().toString())
+                    .set(COMMAND_ID, commandRequest.commandId().id().toString())
                     .set(COMMAND, command)
                     .build();
         }
@@ -54,7 +54,7 @@ public final class AvroSerdes {
             final Sequence readSequence = Sequence.position((Long) record.get(READ_SEQUENCE));
             final CommandId commandId = CommandId.of(UUID.fromString(String.valueOf(record.get(COMMAND_ID))));
             final GenericRecord command = (GenericRecord) record.get(COMMAND);
-            return new CommandRequest<>(aggregateKey, command, readSequence, commandId);
+            return new CommandRequest<>(commandId, aggregateKey, readSequence, command);
         }
 
         private static Schema commandRequestSchema(final GenericRecord command, final GenericRecord key) {
@@ -188,7 +188,7 @@ public final class AvroSerdes {
             return new GenericRecordBuilder(schema)
                     .set(AGGREGATE_KEY, commandResponse.aggregateKey())
                     .set(READ_SEQUENCE, commandResponse.readSequence().getSeq())
-                    .set(COMMAND_ID, commandResponse.commandId().toString())
+                    .set(COMMAND_ID, commandResponse.commandId().id().toString())
                     .set(RESULT, commandResponse.sequenceResult().fold(
                             reasons -> new GenericRecordBuilder(responseFailureSchema)
                                     .set(REASON, fromReason(reasonSchema, reasons.head()))
@@ -230,7 +230,7 @@ public final class AvroSerdes {
                 result = Result.failure(new NonEmptyList<>(commandError, additionalCommandErrors));
             }
 
-            return new CommandResponse<>(aggregateKey, CommandId.of(commandId), readSequence, result);
+            return new CommandResponse<>(CommandId.of(commandId), aggregateKey, readSequence, result);
         }
 
         private static CommandError toCommandError(final GenericRecord record) {

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonAggregateSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonAggregateSerdes.java
@@ -141,10 +141,10 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
         ) throws JsonParseException {
             final JsonObject wrapper = jsonElement.getAsJsonObject();
             return new CommandRequest<>(
+                    CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString())),
                     keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
-                    commandMapper.fromGeneric(wrapper.get(COMMAND)),
                     Sequence.position(wrapper.getAsJsonPrimitive(READ_SEQUENCE).getAsLong()),
-                    CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString())));
+                    commandMapper.fromGeneric(wrapper.get(COMMAND)));
         }
     }
 
@@ -298,8 +298,8 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
                 );
             }
             return new CommandResponse(
-                    keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
                     commandId,
+                    keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
                     readSequence,
                     result);
         }

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonAggregateSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonAggregateSerdes.java
@@ -4,6 +4,7 @@ import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import io.simplesource.api.CommandError.Reason;
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Sequence;
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
@@ -29,7 +30,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
 
     private final Serde<K> ak;
     private final Serde<CommandRequest<K, C>> cr;
-    private final Serde<UUID> crk;
+    private final Serde<CommandId> crk;
     private final Serde<ValueWithSequence<E>> vws;
     private final Serde<AggregateUpdate<A>> au;
     private final Serde<CommandResponse<K>> cr2;
@@ -51,7 +52,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
 
         final GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(CommandRequest.class, new CommandRequestAdapter());
-        gsonBuilder.registerTypeAdapter(UUID.class, new UUIDAdapter());
+        gsonBuilder.registerTypeAdapter(CommandId.class, new CommandIdAdapter());
         gsonBuilder.registerTypeAdapter(ValueWithSequence.class, new ValueWithSequenceAdapter());
         gsonBuilder.registerTypeAdapter(AggregateUpdate.class, new AggregateUpdateAdapter());
         gsonBuilder.registerTypeAdapter(CommandResponse.class, new CommandResponseAdapter());
@@ -67,7 +68,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
                 }.getType()));
         crk = GenericSerde.of(serde,
                 gson::toJson,
-                s -> gson.fromJson(s, new TypeToken<UUID>() {
+                s -> gson.fromJson(s, new TypeToken<CommandId>() {
                 }.getType()));
         vws = GenericSerde.of(serde,
                 gson::toJson,
@@ -94,7 +95,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
     }
 
     @Override
-    public Serde<UUID> commandResponseKey() {
+    public Serde<CommandId> commandResponseKey() {
         return crk;
     }
 
@@ -129,7 +130,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
             final JsonObject wrapper = new JsonObject();
             wrapper.add(AGGREGATE_KEY, keyMapper.toGeneric(commandRequest.aggregateKey()));
             wrapper.addProperty(READ_SEQUENCE, commandRequest.readSequence().getSeq());
-            wrapper.addProperty(COMMAND_ID, commandRequest.commandId().toString());
+            wrapper.addProperty(COMMAND_ID, commandRequest.commandId().id().toString());
             wrapper.add(COMMAND, commandMapper.toGeneric(commandRequest.command()));
             return wrapper;
         }
@@ -143,31 +144,31 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
                     keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
                     commandMapper.fromGeneric(wrapper.get(COMMAND)),
                     Sequence.position(wrapper.getAsJsonPrimitive(READ_SEQUENCE).getAsLong()),
-                    UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString()));
+                    CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString())));
         }
     }
 
-    private class UUIDAdapter implements JsonSerializer<UUID>, JsonDeserializer<UUID> {
+    private class CommandIdAdaptor implements JsonSerializer<CommandId>, JsonDeserializer<CommandId> {
 
         private static final String COMMAND_ID = "commandId";
 
         @Override
         public JsonElement serialize(
-                final UUID uuid,
+                final CommandId commandId,
                 final Type type,
                 final JsonSerializationContext jsonSerializationContext
         ) {
             final JsonObject wrapper = new JsonObject();
-            wrapper.addProperty(COMMAND_ID, uuid.toString());
+            wrapper.addProperty(COMMAND_ID, commandId.id().toString());
             return wrapper;
         }
 
         @Override
-        public UUID deserialize(
+        public CommandId deserialize(
                 final JsonElement jsonElement, final Type type, final JsonDeserializationContext jsonDeserializationContext
         ) throws JsonParseException {
             final JsonObject wrapper = jsonElement.getAsJsonObject();
-            return UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString());
+            return CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString()));
         }
     }
 
@@ -248,7 +249,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
         ) {
             final JsonObject wrapper = new JsonObject();
             wrapper.addProperty(READ_SEQUENCE, commandResponse.readSequence().getSeq());
-            wrapper.addProperty(COMMAND_ID, commandResponse.commandId().toString());
+            wrapper.addProperty(COMMAND_ID, commandResponse.commandId().id().toString());
             wrapper.add(AGGREGATE_KEY, keyMapper.toGeneric(commandResponse.aggregateKey()));
             wrapper.add(RESULT, commandResponse.sequenceResult().fold(
                     reasons -> {
@@ -281,7 +282,7 @@ public final class JsonAggregateSerdes<K, C, E, A> extends JsonSerdes<K, C> impl
         ) throws JsonParseException {
             final JsonObject wrapper = jsonElement.getAsJsonObject();
             final Sequence readSequence = Sequence.position(wrapper.getAsJsonPrimitive(READ_SEQUENCE).getAsLong());
-            final UUID commandId = UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString());
+            final CommandId commandId = CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString()));
             final JsonObject resultWrapper = wrapper.getAsJsonObject(RESULT);
             final Result result;
             if (resultWrapper.has(REASON)) {

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonCommandSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonCommandSerdes.java
@@ -1,25 +1,18 @@
 package io.simplesource.kafka.serialization.json;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
-import io.simplesource.api.CommandError;
-import io.simplesource.api.CommandError.Reason;
 import io.simplesource.api.CommandId;
-import io.simplesource.data.NonEmptyList;
-import io.simplesource.data.Result;
-import io.simplesource.data.Sequence;
-import io.simplesource.kafka.api.AggregateSerdes;
 import io.simplesource.kafka.api.CommandSerdes;
-import io.simplesource.kafka.model.*;
+import io.simplesource.kafka.model.CommandRequest;
+import io.simplesource.kafka.model.CommandResponse;
 import io.simplesource.kafka.serialization.util.GenericMapper;
 import io.simplesource.kafka.serialization.util.GenericSerde;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 import static io.simplesource.kafka.serialization.json.JsonGenericMapper.jsonDomainMapper;
 

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonCommandSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonCommandSerdes.java
@@ -4,6 +4,7 @@ import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import io.simplesource.api.CommandError;
 import io.simplesource.api.CommandError.Reason;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
@@ -30,7 +31,7 @@ public final class JsonCommandSerdes<K, C> extends JsonSerdes<K, C> implements C
 
     private final Serde<K> ak;
     private final Serde<CommandRequest<K, C>> cr;
-    private final Serde<UUID> crk;
+    private final Serde<CommandId> crk;
     private final Serde<CommandResponse<K>> cr2;
 
     public JsonCommandSerdes() {
@@ -46,7 +47,7 @@ public final class JsonCommandSerdes<K, C> extends JsonSerdes<K, C> implements C
 
         final GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(CommandRequest.class, new CommandRequestAdapter());
-        gsonBuilder.registerTypeAdapter(UUID.class, new UUIDAdapter());
+        gsonBuilder.registerTypeAdapter(CommandId.class, new CommandIdAdapter());
         gsonBuilder.registerTypeAdapter(CommandResponse.class, new CommandResponseAdapter());
         gson = gsonBuilder.create();
         parser = new JsonParser();
@@ -60,7 +61,7 @@ public final class JsonCommandSerdes<K, C> extends JsonSerdes<K, C> implements C
                 }.getType()));
         crk = GenericSerde.of(serde,
                 gson::toJson,
-                s -> gson.fromJson(s, new TypeToken<UUID>() {
+                s -> gson.fromJson(s, new TypeToken<CommandId>() {
                 }.getType()));
         cr2 = GenericSerde.of(serde,
                 gson::toJson,
@@ -79,7 +80,7 @@ public final class JsonCommandSerdes<K, C> extends JsonSerdes<K, C> implements C
     }
 
     @Override
-    public Serde<UUID> commandResponseKey() {
+    public Serde<CommandId> commandResponseKey() {
         return crk;
     }
 

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonSerdes.java
@@ -2,6 +2,7 @@ package io.simplesource.kafka.serialization.json;
 
 import com.google.gson.*;
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
@@ -39,7 +40,7 @@ class JsonSerdes<K, C> {
             final JsonObject wrapper = new JsonObject();
             wrapper.add(AGGREGATE_KEY, keyMapper.toGeneric(commandRequest.aggregateKey()));
             wrapper.addProperty(READ_SEQUENCE, commandRequest.readSequence().getSeq());
-            wrapper.addProperty(COMMAND_ID, commandRequest.commandId().toString());
+            wrapper.addProperty(COMMAND_ID, commandRequest.commandId().id().toString());
             wrapper.add(COMMAND, commandMapper.toGeneric(commandRequest.command()));
             return wrapper;
         }
@@ -53,31 +54,31 @@ class JsonSerdes<K, C> {
                     keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
                     commandMapper.fromGeneric(wrapper.get(COMMAND)),
                     Sequence.position(wrapper.getAsJsonPrimitive(READ_SEQUENCE).getAsLong()),
-                    UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString()));
+                    CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString())));
         }
     }
 
-    class UUIDAdapter implements JsonSerializer<UUID>, JsonDeserializer<UUID> {
+    class CommandIdAdapter implements JsonSerializer<CommandId>, JsonDeserializer<CommandId> {
 
         private static final String COMMAND_ID = "commandId";
 
         @Override
         public JsonElement serialize(
-                final UUID uuid,
+                final CommandId commandId,
                 final Type type,
                 final JsonSerializationContext jsonSerializationContext
         ) {
             final JsonObject wrapper = new JsonObject();
-            wrapper.addProperty(COMMAND_ID, uuid.toString());
+            wrapper.addProperty(COMMAND_ID, commandId.id().toString());
             return wrapper;
         }
 
         @Override
-        public UUID deserialize(
+        public CommandId deserialize(
                 final JsonElement jsonElement, final Type type, final JsonDeserializationContext jsonDeserializationContext
         ) throws JsonParseException {
             final JsonObject wrapper = jsonElement.getAsJsonObject();
-            return UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString());
+            return CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString()));
         }
     }
 
@@ -102,7 +103,7 @@ class JsonSerdes<K, C> {
         ) {
             final JsonObject wrapper = new JsonObject();
             wrapper.addProperty(READ_SEQUENCE, commandResponse.readSequence().getSeq());
-            wrapper.addProperty(COMMAND_ID, commandResponse.commandId().toString());
+            wrapper.addProperty(COMMAND_ID, commandResponse.commandId().id().toString());
             wrapper.add(AGGREGATE_KEY, keyMapper.toGeneric(commandResponse.aggregateKey()));
             wrapper.add(RESULT, commandResponse.sequenceResult().fold(
                     reasons -> {
@@ -135,7 +136,7 @@ class JsonSerdes<K, C> {
         ) throws JsonParseException {
             final JsonObject wrapper = jsonElement.getAsJsonObject();
             final Sequence readSequence = Sequence.position(wrapper.getAsJsonPrimitive(READ_SEQUENCE).getAsLong());
-            final UUID commandId = UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString());
+            final CommandId commandId = CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString()));
             final JsonObject resultWrapper = wrapper.getAsJsonObject(RESULT);
             final Result result;
             if (resultWrapper.has(REASON)) {

--- a/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonSerdes.java
+++ b/simplesource-command-serialization/src/main/java/io/simplesource/kafka/serialization/json/JsonSerdes.java
@@ -51,10 +51,10 @@ class JsonSerdes<K, C> {
         ) throws JsonParseException {
             final JsonObject wrapper = jsonElement.getAsJsonObject();
             return new CommandRequest<>(
+                    CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString())),
                     keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
-                    commandMapper.fromGeneric(wrapper.get(COMMAND)),
                     Sequence.position(wrapper.getAsJsonPrimitive(READ_SEQUENCE).getAsLong()),
-                    CommandId.of(UUID.fromString(wrapper.getAsJsonPrimitive(COMMAND_ID).getAsString())));
+                    commandMapper.fromGeneric(wrapper.get(COMMAND)));
         }
     }
 
@@ -152,8 +152,8 @@ class JsonSerdes<K, C> {
                 );
             }
             return new CommandResponse<>(
-                    keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
                     commandId,
+                    keyMapper.fromGeneric(wrapper.get(AGGREGATE_KEY)),
                     readSequence,
                     result);
         }

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroAggregateSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroAggregateSerdeTests.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.serialization.avro.mappers;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
 import io.simplesource.kafka.api.AggregateSerdes;
@@ -41,10 +42,10 @@ public class AvroAggregateSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        UUID responseKey = UUID.randomUUID();
+        CommandId responseKey = CommandId.of(UUID.randomUUID());
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
-        UUID deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
+        CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
         assertThat(deserialised).isEqualTo(responseKey);
     }
 
@@ -67,7 +68,7 @@ public class AvroAggregateSerdeTests {
                 aggKey,
                 new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                UUID.randomUUID());
+                CommandId.of(UUID.randomUUID()));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -90,7 +91,7 @@ public class AvroAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
         CommandResponse commandResponse = new CommandResponse(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of(UUID.randomUUID()),
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -104,7 +105,7 @@ public class AvroAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
         CommandResponse commandResponse = new CommandResponse(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of(UUID.randomUUID()),
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroAggregateSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroAggregateSerdeTests.java
@@ -65,10 +65,10 @@ public class AvroAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
+                CommandId.of(UUID.randomUUID()),
                 aggKey,
-                new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                CommandId.of(UUID.randomUUID()));
+                new UserAccountDomainCommand.UpdateUserName("name"));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -90,8 +90,8 @@ public class AvroAggregateSerdeTests {
     void commandResponseSuccess() {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
         CommandResponse commandResponse = new CommandResponse(
-                aggKey,
                 CommandId.of(UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -104,8 +104,8 @@ public class AvroAggregateSerdeTests {
     void commandResponseFailure() {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
         CommandResponse commandResponse = new CommandResponse(
-                aggKey,
                 CommandId.of(UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroAggregateSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroAggregateSerdeTests.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +41,7 @@ public class AvroAggregateSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        CommandId responseKey = CommandId.of(UUID.randomUUID());
+        CommandId responseKey = CommandId.random();
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
         CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
@@ -65,7 +64,7 @@ public class AvroAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 new UserAccountDomainCommand.UpdateUserName("name"));
@@ -90,7 +89,7 @@ public class AvroAggregateSerdeTests {
     void commandResponseSuccess() {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
         CommandResponse commandResponse = new CommandResponse(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
@@ -104,7 +103,7 @@ public class AvroAggregateSerdeTests {
     void commandResponseFailure() {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
         CommandResponse commandResponse = new CommandResponse(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroCommandSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroCommandSerdeTests.java
@@ -12,7 +12,6 @@ import io.simplesource.kafka.serialization.avro.mappers.domain.UserAccountDomain
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +38,7 @@ class AvroCommandSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        CommandId responseKey = CommandId.of(UUID.randomUUID());
+        CommandId responseKey = CommandId.random();
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
         CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
@@ -51,7 +50,7 @@ class AvroCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 new UserAccountDomainCommand.UpdateUserName("name"));
@@ -66,7 +65,7 @@ class AvroCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse<>(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
@@ -81,7 +80,7 @@ class AvroCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse<>(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroCommandSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroCommandSerdeTests.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.serialization.avro.mappers;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
 import io.simplesource.kafka.model.CommandRequest;
@@ -38,11 +39,11 @@ class AvroCommandSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        UUID responseKey = UUID.randomUUID();
+        CommandId responseKey = CommandId.of(UUID.randomUUID());
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
-        UUID deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
-        assertThat(deserialised).isEqualTo(responseKey);
+        CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
+        assertThat(deserialised).isEqualToComparingFieldByField(responseKey);
     }
 
     @Test
@@ -53,7 +54,7 @@ class AvroCommandSerdeTests {
                 aggKey,
                 new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                UUID.randomUUID());
+                CommandId.of(UUID.randomUUID()));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -66,7 +67,7 @@ class AvroCommandSerdeTests {
 
         CommandResponse commandResponse = new CommandResponse<>(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of(UUID.randomUUID()),
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -81,7 +82,7 @@ class AvroCommandSerdeTests {
 
         CommandResponse commandResponse = new CommandResponse<>(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of(UUID.randomUUID()),
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroCommandSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/AvroCommandSerdeTests.java
@@ -51,10 +51,10 @@ class AvroCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
+                CommandId.of(UUID.randomUUID()),
                 aggKey,
-                new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                CommandId.of(UUID.randomUUID()));
+                new UserAccountDomainCommand.UpdateUserName("name"));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -66,8 +66,8 @@ class AvroCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse<>(
-                aggKey,
                 CommandId.of(UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -81,8 +81,8 @@ class AvroCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse<>(
-                aggKey,
                 CommandId.of(UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonAggregateSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonAggregateSerdeTests.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +41,7 @@ public class JsonAggregateSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        CommandId responseKey = CommandId.of(UUID.randomUUID());
+        CommandId responseKey = CommandId.random();
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
         CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
@@ -65,7 +64,7 @@ public class JsonAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
-                CommandId.of( UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 new UserAccountDomainCommand.UpdateUserName("name"));
@@ -91,7 +90,7 @@ public class JsonAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                CommandId.of( UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
@@ -106,7 +105,7 @@ public class JsonAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                CommandId.of( UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonAggregateSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonAggregateSerdeTests.java
@@ -65,10 +65,10 @@ public class JsonAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
+                CommandId.of( UUID.randomUUID()),
                 aggKey,
-                new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                CommandId.of( UUID.randomUUID()));
+                new UserAccountDomainCommand.UpdateUserName("name"));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -91,8 +91,8 @@ public class JsonAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                aggKey,
                 CommandId.of( UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -106,8 +106,8 @@ public class JsonAggregateSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                aggKey,
                 CommandId.of( UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonAggregateSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonAggregateSerdeTests.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.serialization.avro.mappers;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
 import io.simplesource.kafka.api.AggregateSerdes;
@@ -41,10 +42,10 @@ public class JsonAggregateSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        UUID responseKey = UUID.randomUUID();
+        CommandId responseKey = CommandId.of(UUID.randomUUID());
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
-        UUID deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
+        CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
         assertThat(deserialised).isEqualTo(responseKey);
     }
 
@@ -67,7 +68,7 @@ public class JsonAggregateSerdeTests {
                 aggKey,
                 new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                UUID.randomUUID());
+                CommandId.of( UUID.randomUUID()));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -91,7 +92,7 @@ public class JsonAggregateSerdeTests {
 
         CommandResponse commandResponse = new CommandResponse(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of( UUID.randomUUID()),
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -106,7 +107,7 @@ public class JsonAggregateSerdeTests {
 
         CommandResponse commandResponse = new CommandResponse(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of( UUID.randomUUID()),
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonCommandSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonCommandSerdeTests.java
@@ -12,8 +12,6 @@ import io.simplesource.kafka.serialization.json.JsonCommandSerdes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonCommandSerdeTests {
@@ -35,7 +33,7 @@ class JsonCommandSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        CommandId responseKey = CommandId.of(UUID.randomUUID());
+        CommandId responseKey = CommandId.random();
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
         CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
@@ -47,7 +45,7 @@ class JsonCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 new UserAccountDomainCommand.UpdateUserName("name"));
@@ -62,7 +60,7 @@ class JsonCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
@@ -77,7 +75,7 @@ class JsonCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                CommandId.of(UUID.randomUUID()),
+                CommandId.random(),
                 aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonCommandSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonCommandSerdeTests.java
@@ -47,10 +47,10 @@ class JsonCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> commandRequest = new CommandRequest<>(
+                CommandId.of(UUID.randomUUID()),
                 aggKey,
-                new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                CommandId.of(UUID.randomUUID()));
+                new UserAccountDomainCommand.UpdateUserName("name"));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -62,8 +62,8 @@ class JsonCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                aggKey,
                 CommandId.of(UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -77,8 +77,8 @@ class JsonCommandSerdeTests {
         UserAccountDomainKey aggKey = new UserAccountDomainKey("userId");
 
         CommandResponse commandResponse = new CommandResponse(
-                aggKey,
                 CommandId.of(UUID.randomUUID()),
+                aggKey,
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonCommandSerdeTests.java
+++ b/simplesource-command-serialization/src/test/java/io/simplesource/kafka/serialization/avro/mappers/JsonCommandSerdeTests.java
@@ -1,6 +1,7 @@
 package io.simplesource.kafka.serialization.avro.mappers;
 
 import io.simplesource.api.CommandError;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Result;
 import io.simplesource.data.Sequence;
 import io.simplesource.kafka.model.CommandRequest;
@@ -34,10 +35,10 @@ class JsonCommandSerdeTests {
 
     @Test
     void uuidResponseKey() {
-        UUID responseKey = UUID.randomUUID();
+        CommandId responseKey = CommandId.of(UUID.randomUUID());
 
         byte[] serialised = serdes.commandResponseKey().serializer().serialize(topic, responseKey);
-        UUID deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
+        CommandId deserialised = serdes.commandResponseKey().deserializer().deserialize(topic, serialised);
         assertThat(deserialised).isEqualTo(responseKey);
     }
 
@@ -49,7 +50,7 @@ class JsonCommandSerdeTests {
                 aggKey,
                 new UserAccountDomainCommand.UpdateUserName("name"),
                 Sequence.first(),
-                UUID.randomUUID());
+                CommandId.of(UUID.randomUUID()));
 
         byte[] serialised = serdes.commandRequest().serializer().serialize(topic, commandRequest);
         CommandRequest<UserAccountDomainKey, UserAccountDomainCommand> deserialised = serdes.commandRequest().deserializer().deserialize(topic, serialised);
@@ -62,7 +63,7 @@ class JsonCommandSerdeTests {
 
         CommandResponse commandResponse = new CommandResponse(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of(UUID.randomUUID()),
                 Sequence.first(),
                 Result.success(Sequence.first()));
 
@@ -77,7 +78,7 @@ class JsonCommandSerdeTests {
 
         CommandResponse commandResponse = new CommandResponse(
                 aggKey,
-                UUID.randomUUID(),
+                CommandId.of(UUID.randomUUID()),
                 Sequence.first(),
                 Result.failure(CommandError.of(CommandError.Reason.InvalidReadSequence, "Invalid sequence")));
 

--- a/simplesource-command-testutils/src/main/java/io/simplesource/kafka/testutils/AggregateTestHelper.java
+++ b/simplesource-command-testutils/src/main/java/io/simplesource/kafka/testutils/AggregateTestHelper.java
@@ -16,7 +16,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -41,7 +40,7 @@ public final class AggregateTestHelper<K, C, E, A> {
         final K key,
         final Sequence readSequence,
         final C command) {
-        final CommandId commandId = CommandId.of(UUID.randomUUID());
+        final CommandId commandId = CommandId.random();
         final Result<CommandError, CommandId> result = testAPI.publishCommand(new CommandAPI.Request<>(key, readSequence, commandId, command))
             .unsafePerform(AggregateTestHelper::commandError);
         return result.fold(

--- a/simplesource-command-testutils/src/main/java/io/simplesource/kafka/testutils/AggregateTestHelper.java
+++ b/simplesource-command-testutils/src/main/java/io/simplesource/kafka/testutils/AggregateTestHelper.java
@@ -3,6 +3,7 @@ package io.simplesource.kafka.testutils;
 import io.simplesource.api.CommandAPI;
 import io.simplesource.api.CommandError;
 import io.simplesource.api.CommandError.Reason;
+import io.simplesource.api.CommandId;
 import io.simplesource.data.Sequence;
 import io.simplesource.data.NonEmptyList;
 import io.simplesource.data.Result;
@@ -36,12 +37,12 @@ public final class AggregateTestHelper<K, C, E, A> {
         return new PublishBuilder(key, readSequence, command);
     }
 
-    private UUID publish(
+    private CommandId publish(
         final K key,
         final Sequence readSequence,
         final C command) {
-        final UUID commandId = UUID.randomUUID();
-        final Result<CommandError, UUID> result = testAPI.publishCommand(new CommandAPI.Request<>(key, readSequence, commandId, command))
+        final CommandId commandId = CommandId.of(UUID.randomUUID());
+        final Result<CommandError, CommandId> result = testAPI.publishCommand(new CommandAPI.Request<>(key, readSequence, commandId, command))
             .unsafePerform(AggregateTestHelper::commandError);
         return result.fold(
             reasons -> {
@@ -61,7 +62,7 @@ public final class AggregateTestHelper<K, C, E, A> {
         final NonEmptyList<E> expectedEvents,
         final A expectedAggregate
     ) {
-        final UUID commandId = publish(key, readSequence, command);
+        final CommandId commandId = publish(key, readSequence, command);
         final NonEmptyList<Sequence> expectedSequences = validateEvents(key, readSequence, expectedEvents);
 
         final KeyValue<K, CommandResponse<K>> updateResponse = testAPI.readCommandResponseTopic()
@@ -96,7 +97,7 @@ public final class AggregateTestHelper<K, C, E, A> {
         final C command,
         final Consumer<NonEmptyList<CommandError>> failureValidator
     ) {
-        final UUID commandId = publish(key, readSequence, command);
+        final CommandId commandId = publish(key, readSequence, command);
 
         final KeyValue<K, CommandResponse<K>>  updateResponse = testAPI.readCommandResponseTopic()
                 .orElseGet(() -> fail("Didn't find command response"));


### PR DESCRIPTION
Taking out `UUID` from the command API.

It still needs to be convertible to and from UUID, but stronger type safety of the command key is required, especially for Sagas.