### PR TITLE
EventAggregateBuilder wrapper and split client away from stream app

### DIFF
--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/client/CommandAPIBuilder.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/client/CommandAPIBuilder.java
@@ -1,4 +1,4 @@
-package io.simplesource.kafka.dsl;
+package io.simplesource.kafka.client;
 
 import io.simplesource.kafka.api.CommandSerdes;
 import io.simplesource.kafka.api.ResourceNamingStrategy;

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/client/EventSourcedClient.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/client/EventSourcedClient.java
@@ -39,14 +39,14 @@ public final class EventSourcedClient {
         return this;
     }
 
-    public CommandAPI<?, ?> createCommandApi(final Consumer<CommandAPIBuilder<?, ?>> buildSteps) {
+    public CommandAPI<?, ?> createCommandAPI(final Consumer<CommandAPIBuilder<?, ?>> buildSteps) {
         CommandAPIBuilder<?, ?> builder = CommandAPIBuilder.newBuilder();
         buildSteps.accept(builder);
         final CommandSpec<?, ?> commandSpec = builder.build();
-        return createCommandApi(commandSpec);
+        return createCommandAPI(commandSpec);
     }
 
-    public CommandAPI<?, ?> createCommandApi(final CommandSpec<?, ?> commandSpec) {
+    public CommandAPI<?, ?> createCommandAPI(final CommandSpec<?, ?> commandSpec) {
         requireNonNull(scheduler, "Scheduler has not been defined. Please define with with 'withScheduler' method.");
 
         return new KafkaCommandAPI(

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/client/EventSourcedClient.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/client/EventSourcedClient.java
@@ -1,7 +1,8 @@
-package io.simplesource.kafka.dsl;
+package io.simplesource.kafka.client;
 
 
 import io.simplesource.api.CommandAPI;
+import io.simplesource.kafka.dsl.KafkaConfig;
 import io.simplesource.kafka.internal.client.KafkaCommandAPI;
 import io.simplesource.kafka.internal.util.NamedThreadFactory;
 import io.simplesource.kafka.spec.CommandSpec;

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventAggregateBuilder.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventAggregateBuilder.java
@@ -1,0 +1,65 @@
+package io.simplesource.kafka.dsl;
+
+import io.simplesource.data.NonEmptyList;
+import io.simplesource.data.Result;
+import io.simplesource.kafka.api.AggregateResources.TopicEntity;
+import io.simplesource.kafka.api.AggregateSerdes;
+import io.simplesource.kafka.api.ResourceNamingStrategy;
+import io.simplesource.kafka.spec.AggregateSpec;
+import io.simplesource.kafka.spec.TopicSpec;
+
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+public final class EventAggregateBuilder<K, E> {
+    private AggregateBuilder<K, E, E, Boolean> builder;
+
+    public static <K, E> EventAggregateBuilder<K, E> newBuilder() {
+        return new EventAggregateBuilder<>();
+    }
+
+    private EventAggregateBuilder() {
+        builder = AggregateBuilder.newBuilder();
+        builder.withInitialValue(k -> true);
+        builder.withCommandHandler((k, a, c) -> Result.success(NonEmptyList.of(c)));
+        builder.withAggregator((x, e) -> true);
+    }
+
+    private EventAggregateBuilder<K, E> apply(Consumer<AggregateBuilder<K, E, E, Boolean>> applyStep) {
+        applyStep.accept(builder);
+        return this;
+    }
+
+    public EventAggregateBuilder<K, E> withName(final String name) {
+        return apply(b -> b.withName(name));
+    }
+
+    public EventAggregateBuilder<K, E> withResourceNamingStrategy(final ResourceNamingStrategy resourceNamingStrategy) {
+        return apply(b -> b.withResourceNamingStrategy(resourceNamingStrategy));
+    }
+
+    public EventAggregateBuilder<K, E> withSerdes(final AggregateSerdes<K, E, E, Boolean> aggregateSerdes) {
+        return apply(b -> b.withSerdes(aggregateSerdes));
+    }
+
+    public EventAggregateBuilder<K, E> withDefaultTopicSpec(final int partitions, final int replication, final int retentionDays) {
+        return apply(b -> b.withDefaultTopicSpec(partitions, replication, retentionDays));
+    }
+
+    public EventAggregateBuilder<K, E> withTopicSpec(final TopicEntity topicEntity, final TopicSpec topicSpec) {
+        return apply(b -> b.withTopicSpec(topicEntity, topicSpec));
+    }
+
+    public EventAggregateBuilder<K, E> withCommandResponseRetention(final long retentionInSeconds) {
+        return apply(b -> b.withCommandResponseRetention(retentionInSeconds));
+    }
+
+    public EventAggregateBuilder<K, E> withInvalidSequenceStrategy(final InvalidSequenceStrategy invalidSequenceStrategy) {
+        return apply(b -> b.withInvalidSequenceStrategy(invalidSequenceStrategy));
+    }
+
+    public AggregateSpec<K, E, E, Boolean> build() {
+        return builder.build();
+    }
+}

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
@@ -1,19 +1,11 @@
 package io.simplesource.kafka.dsl;
 
-import io.simplesource.api.CommandAPI;
-import io.simplesource.kafka.internal.client.KafkaCommandAPI;
 import io.simplesource.kafka.internal.streams.EventSourcedStreamsApp;
-import io.simplesource.kafka.internal.util.NamedThreadFactory;
 import io.simplesource.kafka.spec.AggregateSetSpec;
 import io.simplesource.kafka.spec.AggregateSpec;
-import io.simplesource.kafka.spec.CommandSpec;
-import io.simplesource.kafka.util.SpecUtils;
-import org.apache.kafka.streams.errors.StreamsException;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -26,17 +18,20 @@ public final class EventSourcedApp {
 
     public EventSourcedApp withKafkaConfig(
             final Function<KafkaConfig.Builder, KafkaConfig> builder) {
+        requireNotStarted();
         kafkaConfig = builder.apply(new KafkaConfig.Builder());
         return this;
     }
 
     public EventSourcedApp withKafkaConfig(final KafkaConfig kafkaConfig) {
+        requireNotStarted();
         this.kafkaConfig = kafkaConfig;
         return this;
     }
 
     public <K, C, E, A> EventSourcedApp withAggregate(
             final Function<AggregateBuilder<K, C, E, A>, AggregateSpec<K, C, E, A>> buildSteps) {
+        requireNotStarted();
         AggregateBuilder<K, C, E, A> builder = AggregateBuilder.newBuilder();
         final AggregateSpec<K, C, E, A> spec = buildSteps.apply(builder);
         aggregateConfigMap.put(spec.aggregateName(), spec);
@@ -44,12 +39,14 @@ public final class EventSourcedApp {
     }
 
     public <K, C, E, A> EventSourcedApp withAggregate(final AggregateSpec<K, C, E, A> spec) {
+        requireNotStarted();
         aggregateConfigMap.put(spec.aggregateName(), spec);
         return this;
     }
 
     public <K, E> EventSourcedApp withEvent(
             final Consumer<EventAggregateBuilder<K, E>> buildSteps) {
+        requireNotStarted();
         EventAggregateBuilder<K, E> builder = EventAggregateBuilder.newBuilder();
         buildSteps.accept(builder);
         final AggregateSpec<K, E, E, ?> spec = builder.build();
@@ -58,6 +55,7 @@ public final class EventSourcedApp {
     }
 
     public <K, E> EventSourcedApp withEvent(final AggregateSpec<K, E, E, ?> spec) {
+        requireNotStarted();
         aggregateConfigMap.put(spec.aggregateName(), spec);
         return this;
     }
@@ -73,5 +71,9 @@ public final class EventSourcedApp {
         EventSourcedStreamsApp app = new EventSourcedStreamsApp(aggregateSetSpec);
         app.start();
         isStarted = true;
+    }
+
+    private void requireNotStarted() {
+        if (isStarted ) throw new RuntimeException("App already started, and cannot be modified.");
     }
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
@@ -71,8 +71,8 @@ public final class EventSourcedApp {
     }
 
     public void start() {
-        requireNonNull(kafkaConfig, "KafkaConfig has not been defined. Please define it with 'withKafkaConfig' method.");
         if (isStarted) return;
+        requireNonNull(kafkaConfig, "KafkaConfig has not been defined. Please define it with 'withKafkaConfig' method.");
 
         final AggregateSetSpec aggregateSetSpec = new AggregateSetSpec(
                 kafkaConfig,

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
@@ -22,9 +22,6 @@ import static java.util.Objects.requireNonNull;
 public final class EventSourcedApp {
     private KafkaConfig kafkaConfig;
     private Map<String, AggregateSpec<?, ?, ?, ?>> aggregateConfigMap = new HashMap<>();
-    private AggregateSetSpec aggregateSetSpec;
-    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory("EventSourcedApp-scheduler"));
     private boolean isStarted = false;
 
     public EventSourcedApp withKafkaConfig(
@@ -35,11 +32,6 @@ public final class EventSourcedApp {
 
     public EventSourcedApp withKafkaConfig(final KafkaConfig kafkaConfig) {
         this.kafkaConfig = kafkaConfig;
-        return this;
-    }
-
-    public EventSourcedApp withScheduler(final ScheduledExecutorService scheduler) {
-        this.scheduler = scheduler;
         return this;
     }
 

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
@@ -8,6 +8,7 @@ import io.simplesource.kafka.spec.AggregateSetSpec;
 import io.simplesource.kafka.spec.AggregateSpec;
 import io.simplesource.kafka.spec.CommandSpec;
 import io.simplesource.kafka.util.SpecUtils;
+import org.apache.kafka.streams.errors.StreamsException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +25,7 @@ public final class EventSourcedApp {
     private AggregateSetSpec aggregateSetSpec;
     private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
             new NamedThreadFactory("EventSourcedApp-scheduler"));
+    private boolean isStarted = false;
 
     public EventSourcedApp withKafkaConfig(
             final Function<KafkaConfig.Builder, KafkaConfig> builder) {
@@ -70,6 +72,7 @@ public final class EventSourcedApp {
 
     public void start() {
         requireNonNull(kafkaConfig, "KafkaConfig has not been defined. Please define it with 'withKafkaConfig' method.");
+        if (isStarted) return;
 
         final AggregateSetSpec aggregateSetSpec = new AggregateSetSpec(
                 kafkaConfig,
@@ -77,5 +80,6 @@ public final class EventSourcedApp {
 
         EventSourcedStreamsApp app = new EventSourcedStreamsApp(aggregateSetSpec);
         app.start();
+        isStarted = true;
     }
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/dsl/EventSourcedApp.java
@@ -75,7 +75,7 @@ public final class EventSourcedApp {
                 kafkaConfig,
                 aggregateConfigMap);
 
-        EventSourcedStreamsApp x = new EventSourcedStreamsApp(aggregateSetSpec);
-        x.start();
+        EventSourcedStreamsApp app = new EventSourcedStreamsApp(aggregateSetSpec);
+        app.start();
     }
 }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/internal/client/KafkaCommandAPI.java
@@ -24,7 +24,7 @@ import static io.simplesource.kafka.api.AggregateResources.TopicEntity.*;
 
 public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
 
-    private KafkaRequestAPI<K, CommandRequest<K, C>, CommandId, CommandResponse<K>> requestApi;
+    private KafkaRequestAPI<K, CommandRequest<K, C>, CommandId, CommandResponse<K>> requestAPI;
 
     public KafkaCommandAPI(
             final CommandSpec<K, C> commandSpec,
@@ -34,7 +34,7 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
                 commandSpec,
                 kafkaConfig,
                 scheduler);
-        requestApi = new KafkaRequestAPI<>(ctx);
+        requestAPI = new KafkaRequestAPI<>(ctx);
     }
 
     public KafkaCommandAPI(
@@ -49,7 +49,7 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
                 commandSpec,
                 kafkaConfig,
                 scheduler);
-        requestApi = new KafkaRequestAPI<>(ctx, requestSender, responseTopicMapSender, attachReceiver, false);
+        requestAPI = new KafkaRequestAPI<>(ctx, requestSender, responseTopicMapSender, attachReceiver, false);
     }
 
     private static CommandError getCommandError(Throwable e) {
@@ -63,7 +63,7 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
         final CommandRequest<K, C> commandRequest = new CommandRequest<>(
                 request.commandId(), request.key(), request.readSequence(), request.command());
 
-        FutureResult<Exception, RequestPublisher.PublishResult> publishResult = requestApi.publishRequest(request.key(), request.commandId(), commandRequest);
+        FutureResult<Exception, RequestPublisher.PublishResult> publishResult = requestAPI.publishRequest(request.key(), request.commandId(), commandRequest);
 
         return publishResult.errorMap(KafkaCommandAPI::getCommandError)
                 .map(r -> request.commandId());
@@ -71,7 +71,7 @@ public final class KafkaCommandAPI<K, C> implements CommandAPI<K, C> {
 
     @Override
     public FutureResult<CommandError, Sequence> queryCommandResult(final CommandId commandId, final Duration timeout) {
-        CompletableFuture<CommandResponse<K>> completableFuture = requestApi.queryResponse(commandId, timeout);
+        CompletableFuture<CommandResponse<K>> completableFuture = requestAPI.queryResponse(commandId, timeout);
 
         return FutureResult.ofCompletableFuture(completableFuture.thenApply(CommandResponse::sequenceResult));
     }

--- a/simplesource-command-kafka/src/main/java/io/simplesource/kafka/util/KafkaStreamsUtils.java
+++ b/simplesource-command-kafka/src/main/java/io/simplesource/kafka/util/KafkaStreamsUtils.java
@@ -53,16 +53,4 @@ public final class KafkaStreamsUtils {
         } while (!done);
         logger.info("Streams app stable for 5 seconds. Considered up.");
     }
-
-    public static void waitForShutdown(final Logger logger, final KafkaStreams streams) {
-        final CountDownLatch latch = new CountDownLatch(1);
-        Runtime.getRuntime().addShutdownHook(new Thread(latch::countDown));
-        try {
-            latch.await();
-        } catch (Exception e) {
-            logger.warn("Error waiting for shutdown: {}", e);
-            System.exit(1);
-        }
-    }
-
 }

--- a/simplesource-command-testutils/src/main/java/io/simplesource/kafka/testutils/AggregateTestDriver.java
+++ b/simplesource-command-testutils/src/main/java/io/simplesource/kafka/testutils/AggregateTestDriver.java
@@ -99,7 +99,7 @@ public final class AggregateTestDriver<K, C, E, A> {
     public FutureResult<CommandError, Sequence> queryCommandResult(
         final CommandId commandId,
         final Duration timeout) {
-        pollForApiResponse();
+        pollForAPIResponse();
         return commandAPI.queryCommandResult(commandId, timeout);
     }
 
@@ -139,7 +139,7 @@ public final class AggregateTestDriver<K, C, E, A> {
                 record.value()));
     }
 
-    public void pollForApiResponse() {
+    public void pollForAPIResponse() {
         statePollers.forEach(Runnable::run);
     }
 


### PR DESCRIPTION
Added a simple wrapper for writing events with simple sourcing with no validation.
It's a degenerate version of the API where:
* Command = Event
* CommandHandler = (k, e) => [e]
* Aggregate = Boolean (has to be something)
* Aggregator = (k, c) => true

It still doesn't really deal with the Serde issue though. We still have to provide a Serde for all the bits and pieces.
 